### PR TITLE
[fix] Invisible option can be clicked

### DIFF
--- a/sumoselect.css
+++ b/sumoselect.css
@@ -1,5 +1,5 @@
 .SumoSelect p {margin: 0;}
-.SumoSelect{width: 200px;}
+.SumoSelect{width: 100%;}
 
 .SelectBox {padding: 5px 8px;}
 
@@ -102,7 +102,7 @@
      .SumoSelect.disabled > .CaptionCont{border-color:#ccc;box-shadow:none;}
 
     /**Select all button**/
-    .SumoSelect .select-all{border-radius: 3px 3px 0 0;position: relative;border-bottom: 1px solid #ddd;background-color: #fff;padding: 8px 0 3px 35px;height: 20px;cursor: pointer;}
+    .SumoSelect .select-all{border-radius: 3px 3px 0 0;position: relative;border-bottom: 1px solid #ddd;background-color: #fff;padding: 8px 0 3px 35px;cursor: pointer;}
     .SumoSelect .select-all > label, .SumoSelect .select-all > span i{cursor: pointer;}
     .SumoSelect .select-all.partial > span i{background-color:#ccc;}
 

--- a/sumoselect.css
+++ b/sumoselect.css
@@ -5,6 +5,8 @@
 
 .sumoStopScroll{overflow:hidden;}
 
+.SumoSelect > select { height: 0; width: 0; padding: 0; }
+
 /* Filtering style */
 .SumoSelect .hidden { display:none; }
 .SumoSelect .search-txt{display:none;outline:none;}

--- a/sumoselect.css
+++ b/sumoselect.css
@@ -5,11 +5,6 @@
 
 .sumoStopScroll{overflow:hidden;}
 
-/* SumoSelectバグ対策 見えないoptionタグが選択できてしまう現象の対策
- * IE11ではoptionタグにCSSが効かないため、selectタグごとサイズ0pxにして選択できないようにする
- */
-.SumoSelect > select { height: 0; width: 0; padding: 0; }
-
 /* Filtering style */
 .SumoSelect .hidden { display:none; }
 .SumoSelect .search-txt{display:none;outline:none;}
@@ -18,7 +13,8 @@
 .SumoSelect.open>.search>span, .SumoSelect.open>.search>label{visibility:hidden;}
 
 /*this is applied on that hidden select. DO NOT USE display:none; or visiblity:hidden; and Do not override any of these properties. */
-.SelectClass,.SumoUnder { position: absolute; top: 0; left: 0; right: 0; height: 100%; width: 100%; border: none; -webkit-box-sizing: border-box; -moz-box-sizing: border-box; box-sizing: border-box; -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)"; filter: alpha(opacity=0); -moz-opacity: 0; -khtml-opacity: 0; opacity: 0; }
+/* Bootstrapのselect[multiple]にheightを上書きされるため、height: 100%をimportantとする。 */
+.SelectClass,.SumoUnder { position: absolute; top: 0; left: 0; right: 0; height: 100% !important; width: 100%; border: none; -webkit-box-sizing: border-box; -moz-box-sizing: border-box; box-sizing: border-box; -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)"; filter: alpha(opacity=0); -moz-opacity: 0; -khtml-opacity: 0; opacity: 0; }
 .SelectClass{z-index: 1;}
 
     .SumoSelect > .optWrapper > .options  li.opt label, .SumoSelect > .CaptionCont,.SumoSelect .select-all > label { user-select: none; -o-user-select: none; -moz-user-select: none; -khtml-user-select: none; -webkit-user-select: none; }

--- a/sumoselect.css
+++ b/sumoselect.css
@@ -5,6 +5,9 @@
 
 .sumoStopScroll{overflow:hidden;}
 
+/* SumoSelectバグ対策 見えないoptionタグが選択できてしまう現象の対策
+ * IE11ではoptionタグにCSSが効かないため、selectタグごとサイズ0pxにして選択できないようにする
+ */
 .SumoSelect > select { height: 0; width: 0; padding: 0; }
 
 /* Filtering style */


### PR DESCRIPTION
### 概要
- 画面上見えない`option`タグがクリック可能になっていた
- `select`タグのサイズを0pxにすることで実質的にクリック不可能にした
- `display: none`にすると「すべて」を選択したときに機能しなくなるためサイズ0pxで対応
- `option`タグを0pxにする方法もあったが、IEでは`option`タグにCSSが効かないため`select`タグで対応

### レビュー観点
- 追加したスタイルについてのコメントの有無

### 特記事項
なし